### PR TITLE
Remove algorithm from the list of arguments

### DIFF
--- a/matchers-cli/pom.xml
+++ b/matchers-cli/pom.xml
@@ -36,7 +36,6 @@
                         <modulepath/>
                         <argument>--module</argument>
                         <argument>matchers.cli/net.mguenther.matchers.cli.MatchersCli</argument>
-                        <argument>kmp</argument>
                         <argument>abcdfffggffgg</argument>
                         <argument>fgg</argument>
                     </arguments>

--- a/matchers-cli/src/main/java/net/mguenther/matchers/cli/MatchersCli.java
+++ b/matchers-cli/src/main/java/net/mguenther/matchers/cli/MatchersCli.java
@@ -18,7 +18,7 @@ public class MatchersCli {
     public static void main(String[] args) {
 
         if (args.length != 2) {
-            System.err.println("Wrong number of arguments. Expected: <algorithm> <haystack> <needle>");
+            System.err.println("Wrong number of arguments. Expected: <haystack> <needle>");
             System.exit(1);
         }
 


### PR DESCRIPTION
Both the error message in the CLI and the arguments in the exec-maven-plugin's configuration reflect an older stage of the project where the algorithm had to be passed in as the first argument.