### PR TITLE
Fixes missing images in html documentation

### DIFF
--- a/matchers-doc/pom.xml
+++ b/matchers-doc/pom.xml
@@ -46,6 +46,7 @@
                             <requires>
                                 <require>asciidoctor-diagram</require>
                             </requires>
+                            <imagesDir>chapters/images</imagesDir>
                             <attributes>
                                 <toc>left</toc>
                             </attributes>
@@ -114,7 +115,7 @@
                                         <require>asciidoctor-diagram</require>
                                     </requires>
                                     <backend>pdf</backend>
-                                    <imagesDir>../../../target/generated-docs/chapters</imagesDir>
+                                    <imagesDir>../../../target/generated-docs/chapters/images</imagesDir>
                                     <sourceHighlighter>rouge</sourceHighlighter> <!-- coderay also possible -->
                                     <attributes>
                                         <icons>font</icons>

--- a/matchers-doc/src/main/asciidoc/chapters/introduction.adoc
+++ b/matchers-doc/src/main/asciidoc/chapters/introduction.adoc
@@ -1,4 +1,5 @@
 [[section:introduction]]
+ifndef::imagesdir[:imagesdir: images]
 
 ## Introduction
 
@@ -30,12 +31,12 @@ The https://github.com/mguenther/string-matchers/releases/tag/baseline[baseline]
 
 The compile-time dependencies on the level of our Maven modules are shown in the following diagram.
 
-image::images/introduction-baseline-modules.png[]
+image::introduction-baseline-modules.png[]
 [.small]_Figure 1: The application comprises two Maven modules: `matchers-core` which defines the API and strategies and `matchers-cli` which builds on top of the core library._
 
 Let us take a brief look at the internal structure of these Maven modules.
 
-image::images/introduction-baseline-level-1.png[]
+image::introduction-baseline-level-1.png[]
 [.small]_Figure 2: Both modules share the same packages._
 
 Maven module `matchers-core` provides the interface `Matcher`, with a clear contract: An implementation of the `Matcher` interface consumes a large body of text (call it _haystack_) and a fragment of text (call it _needle_) and looks up all the starting indices of fragments of text found in the large body of text. This interface is located in package `net.mguenther.matchers`.

--- a/matchers-doc/src/main/asciidoc/chapters/migrate-to-modules.adoc
+++ b/matchers-doc/src/main/asciidoc/chapters/migrate-to-modules.adoc
@@ -1,4 +1,5 @@
 [[section:migration-matchers-core]]
+ifndef::imagesdir[:imagesdir: images]
 
 ## Modularizing an existing codebase
 
@@ -14,7 +15,7 @@ Through the course of this migration guide, we will denote Maven modules using h
 
 Recall the layout of Maven module `matchers-core`.
 
-image::images/modules-baseline-level-1-only-core.png[]
+image::modules-baseline-level-1-only-core.png[]
 [.small]_Figure 3: Both API and implementation are sharing the same package._
 
 All interfaces and classes reside in the same package. First of all, we will create a new Maven module, call it `matchers-api` that will host a Java module, call it `matchers.api`, comprising the API for our string matching algorithms. The interface `Matcher` is copied over to this module and we will expose it to other modules by exporting the whole package footnote:[This is okay, since this module comprises only classes and interfaces that contribute to the public API of our application.]. We will keep the interface `Matchers` in its original module as well, so the build does not break just yet.
@@ -71,14 +72,14 @@ _Package 'net.mguenther.matchers' exists in another module: 'matchers.api'_
 
 Let us take a step back and look at what we achieved so far.
 
-image::images/modules-naive-separation-with-split-packages.png[]
+image::modules-naive-separation-with-split-packages.png[]
 [.small]_Figure 4: The JPMS prohibits packages that are shared across multiple modules._
 
 Although the separation into two distinct modules fits quite nicely, the package boundaries do not: We introduced a so called _split package_. A split package is a package that spans multiple modules. The JPMS enforces that a single package has its dedicated Java module and thus prohibits the use of split packages. From a package design perspective, this seems a bit unnatural as both modules contribute to the same component and, at least from my understanding, a component can surely span multiple modules footnote:[The closure of a component must not even be known at compile time. Think of pluggable application architectures, in which you simply add modules (JARs) to the module path to extend the functionality of a component.].
 
 Anyhow, to fix the issue, we have to abide by the rule that a Java module cannot share packages it contains with another module, so we rename `net.mguenther.matchers` of module `matchers.impl` into `net.mguenther.matchers.impl` for the time being. We end up with a working solution that looks like this.
 
-image::images/modules-naive-separation-without-split-packages.png[]
+image::modules-naive-separation-without-split-packages.png[]
 [.small]_Figure 5: Each Java module has to use its own package._
 
 The standard Maven directory layout still applies, even if we take the JUnit tests into account that exist for the matcher implementations. After applying all changes, it should look like this.
@@ -124,7 +125,7 @@ module matchers.cli {
 
 With this module descriptor in place, the solution comprising all three modules should build and run perfectly fine. Have a look at what we achieved so far in terms of (enclosing) Maven modules. Note that there is a 1:1-correlation between the dependency graph of the Maven modules and the dependency graph of the resp. Java modules.
 
-image::images/modules-naive-separation-java-modules.png[]
+image::modules-naive-separation-java-modules.png[]
 [.small]_Figure 6: The CLI still has an unwanted dependency on `matchers.impl`._
 
 But contrary to our initial mission statement, this makes one thing quite obvious: We are still not getting rid of the unwanted dependency from CLI to the implementation. We will address this issue in the following chapter.

--- a/matchers-doc/src/main/asciidoc/chapters/refactor-to-service-providers.adoc
+++ b/matchers-doc/src/main/asciidoc/chapters/refactor-to-service-providers.adoc
@@ -1,4 +1,5 @@
 [[section:migration-service-loaders]]
+ifndef::imagesdir[:imagesdir: images]
 
 ## Using service loaders
 
@@ -41,7 +42,7 @@ It is not possible to provide more than a single implementation for a given inte
 
 Due to the limited capabilities of the Service Loader API we have to split up our modules even further. Here is what our final solution will look like.
 
-image::images/service-provider-java-modules.png[]
+image::service-provider-java-modules.png[]
 [.small]_Figure 7: Each string matching algorithm to its own Java module, thus enabling an even better form of loose coupling via service providers._
 
 This will provide a very clean separation between the CLI and our algorithms, since both only have to depend on module `matchers.api`. We will not go into much detail on splitting up those modules again, since we have done this exhaustively during the course of the last chapter. So, to sum up: We will move `BruteForceMatcher` into a Java module called `matchers.naive` (with its enclosing Maven module `matchers-naive`) and the `KnuthMorrisPrattMatcher` into module `matchers.kmp` (with its enclosing Maven module `matchers-kmp`). After introducing these two new modules, we can get rid of `matchers.impl` altogether.

--- a/matchers-doc/src/main/asciidoc/chapters/use-default-implementations.adoc
+++ b/matchers-doc/src/main/asciidoc/chapters/use-default-implementations.adoc
@@ -1,10 +1,11 @@
 [[section:use-default-implementations]]
+ifndef::imagesdir[:imagesdir: images]
 
 ## Using a default service provider
 
 What if there is no module on the module path that provides a suitable implementation of `Matcher`? What if there is no implementation of that interface at all? In this case, it is possible to provide a default implementation alongside the public API. The benefit is, that once the API module is distributed, it can definitely be put to use, even if the default implementation does not exhibit the quality aspects that we aimed for. Providing a default implementation is quite simple. Let us have a look again at the module graph of our application.
 
-image::images/service-provider-java-modules.png[]
+image::service-provider-java-modules.png[]
 [.small]_Figure 8: The current state of affairs for our little string matching application._
 
 We currently have two distinct implementations of the public API as exposed via module `matchers.api`. One of these implementations features an elaborate and fast algorithm designed by Knuth, Morris and Pratt. The other one is a rather naive implementation that follows a brute-force technique. Deliberately selecting the brute-force algorithm over the more sophisticated Knuth-Morris-Pratt matcher is probably not going to happen considering its performance characteristics. However, it is a stable solution and solves the given problem. We could use it as a fallback mechanism in case there is no implementation that satisfies the quality constraints or in case there is no additional module at all which could provide an implementation.
@@ -42,7 +43,7 @@ matchers-api
 
 Module `matchers.naive` is no longer required and can be safely removed from the project altogether with its corresponding Maven module `matchers-naive`. We end up with a module graph like the following.
 
-image::images/default-java-modules.png[]
+image::default-java-modules.png[]
 [.small]_Figure 9: The final module graph after removing the obsolete module `matchers.naive`._
 
 The API module does not have to export the default implementation - it will remain an implementation detail of the module. But it has to provide the same service that the original module `matchers.naive` provided as well. This is easily done by a small adjustment to the module descriptor of module `matchers.api` footnote:[`import` statements are omitted.].

--- a/matchers-doc/src/main/asciidoc/string-matchers.adoc
+++ b/matchers-doc/src/main/asciidoc/string-matchers.adoc
@@ -5,7 +5,7 @@
 :stylesdir: css/
 :source-highlighter: coderay
 :numbered:
-:imagesdir: chapters
+:imagesdir: chapters/images
 :icons: font
 :pdf-stylesdir: css/
 :pdf-style: article


### PR DESCRIPTION
With this configuration the images appear in the rendered html and pdf docs as well as the IntelliJ previews of master and child documents.

Fixes #2 